### PR TITLE
Allowed for use of array objects when describing additional stacks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const _ = require('lodash')
+const merge = require('lodash.merge')
 
 class AdditionalStacksPlugin {
   constructor(serverless, options) {
@@ -105,7 +105,7 @@ class AdditionalStacksPlugin {
         return [k, v.reduce((memo, value) => {
           if (value) {
             if (typeof value === 'object') {
-              return _.merge(memo, value);
+              return merge(memo, value);
             }
             throw new Error(`Non-object value specified in ${key} array: ${value}`);
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "serverless-plugin-additional-stacks",
   "version": "1.4.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "test": "cd test && npm run test"
   },
   "dependencies": {
-    "lodash": "^4.17.15"
+    "lodash.merge": "^4.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "license": "MIT",
   "scripts": {
     "test": "cd test && npm run test"
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
   }
 }

--- a/test/service/serverless.yml
+++ b/test/service/serverless.yml
@@ -1,3 +1,5 @@
+org: cpcheatsnerak2007
+app: my-first-app
 # Welcome to Serverless!
 #
 # This file is the main config file for your service.
@@ -121,3 +123,6 @@ custom:
           Type: AWS::SNS::Topic
           Properties:
             TopicName: "${self:service}-secondary-${opt:topicname, self:custom.topicName}-${self:custom.stage}"
+    tertiary:
+      - ${file(tertiary-meta.yml)}
+      - ${file(tertiary-resource.yml)}

--- a/test/service/tertiary-meta.yml
+++ b/test/service/tertiary-meta.yml
@@ -1,0 +1,4 @@
+Deploy: After
+StackName: ${self:service}-${self:custom.stage}-customname-tertiary
+Tags:
+  Owner: yetanother@example.org

--- a/test/service/tertiary-resource.yml
+++ b/test/service/tertiary-resource.yml
@@ -1,0 +1,5 @@
+Resources:
+  SnsTopicTertiary:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: "${self:service}-tertiary-${opt:topicname, self:custom.topicName}-${self:custom.stage}"

--- a/test/tests.js
+++ b/test/tests.js
@@ -15,6 +15,13 @@ const childProcess = require('child_process')
 const path = require('path')
 const chalk = require('chalk')
 
+// set region if not set (as not set by the SDK by default)
+if (!AWS.config.region) {
+  AWS.config.update({
+    region: 'us-east-1'
+  });
+}
+
 const cloudformation = new AWS.CloudFormation()
 chai.use(chaiAsPromised)
 const assert = chai.assert
@@ -25,6 +32,8 @@ const PRIMARY_STACK = 'primary'
 const PRIMARY_STACK_FULLNAME = 'additional-stacks-plugin-service-test-primary'
 const SECONDARY_STACK = 'secondary'
 const SECONDARY_STACK_FULLNAME = 'additional-stacks-plugin-service-test-customname-secondary'
+const TERTIARY_STACK = 'tertiary'
+const TERTIARY_STACK_FULLNAME = 'additional-stacks-plugin-service-test-customname-tertiary'
 
 function sls(args) {
   console.log('   ', chalk.gray.dim('$'), chalk.gray.dim('sls ' + args.join(' ')))
@@ -95,6 +104,7 @@ function describeAllStacks() {
     describeStack(BASE_STACK_FULLNAME),
     describeStack(PRIMARY_STACK_FULLNAME),
     describeStack(SECONDARY_STACK_FULLNAME),
+    describeStack(TERTIARY_STACK_FULLNAME),
   ])
 }
 
@@ -116,6 +126,9 @@ function deleteAllStacks() {
   .then(() => {
     return deleteStack(SECONDARY_STACK_FULLNAME)
   })
+  .then(() => {
+    return deleteStack(TERTIARY_STACK_FULLNAME)
+  })
 }
 
 describe('Automatic Stack Deployment', () => {
@@ -136,12 +149,15 @@ describe('Automatic Stack Deployment', () => {
       assert.isOk(responses[0], 'serverless stack')
       assert.isOk(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
+      assert.isOk(responses[3], 'tertiary stack')
       assert.equal(responses[0].StackStatus, 'UPDATE_COMPLETE', 'serverless stack')
       assert.equal(responses[1].StackStatus, 'CREATE_COMPLETE', 'primary stack')
       assert.equal(responses[2].StackStatus, 'CREATE_COMPLETE', 'secondary stack')
+      assert.equal(responses[3].StackStatus, 'CREATE_COMPLETE', 'tertiary stack')
       assert.equal(responses[0].Tags.filter(tag => tag.Key === 'Owner')[0].Value, 'owner@example.org', 'serverless stack custom tag')
       assert.equal(responses[1].Tags.filter(tag => tag.Key === 'Owner')[0].Value, 'owner@example.org', 'primary stack custom tag')
       assert.equal(responses[2].Tags.filter(tag => tag.Key === 'Owner')[0].Value, 'another@example.org', 'secondary stack custom tag')
+      assert.equal(responses[3].Tags.filter(tag => tag.Key === 'Owner')[0].Value, 'yetanother@example.org', 'tertiary stack custom tag')
     })
   })
 
@@ -157,9 +173,11 @@ describe('Automatic Stack Deployment', () => {
       assert.isOk(responses[0], 'serverless stack')
       assert.isOk(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
+      assert.isOk(responses[3], 'tertiary stack')
       assert.equal(responses[0].StackStatus, 'UPDATE_COMPLETE', 'serverless stack')
       assert.equal(responses[1].StackStatus, 'CREATE_COMPLETE', 'primary stack')
       assert.equal(responses[2].StackStatus, 'CREATE_COMPLETE', 'secondary stack')
+      assert.equal(responses[3].StackStatus, 'CREATE_COMPLETE', 'tertiary stack')
     })
   })
 
@@ -176,9 +194,11 @@ describe('Automatic Stack Deployment', () => {
       assert.isOk(responses[0], 'serverless stack')
       assert.isOk(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
+      assert.isOk(responses[3], 'tertiary stack')
       assert.equal(responses[0].StackStatus, 'UPDATE_COMPLETE', 'serverless stack')
       assert.equal(responses[1].StackStatus, 'CREATE_COMPLETE', 'primary stack')
       assert.equal(responses[2].StackStatus, 'UPDATE_COMPLETE', 'secondary stack')
+      assert.equal(responses[3].StackStatus, 'CREATE_COMPLETE', 'tertiary stack')
     })
   })
 
@@ -194,8 +214,10 @@ describe('Automatic Stack Deployment', () => {
       assert.isNull(responses[0], 'serverless stack')
       assert.isOk(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
+      assert.isOk(responses[3], 'tertiary stack')
       assert.equal(responses[1].StackStatus, 'CREATE_COMPLETE', 'primary stack')
       assert.equal(responses[2].StackStatus, 'UPDATE_COMPLETE', 'secondary stack')
+      assert.equal(responses[3].StackStatus, 'CREATE_COMPLETE', 'tertiary stack')
     })
   })
 })
@@ -218,8 +240,10 @@ describe('Manual Stack Deployment', () => {
       assert.isNull(responses[0], 'serverless stack')
       assert.isOk(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
+      assert.isOk(responses[3], 'tertiary stack')
       assert.equal(responses[1].StackStatus, 'CREATE_COMPLETE', 'primary stack')
       assert.equal(responses[2].StackStatus, 'CREATE_COMPLETE', 'secondary stack')
+      assert.equal(responses[3].StackStatus, 'CREATE_COMPLETE', 'tertiary stack')
     })
   })
 
@@ -235,8 +259,10 @@ describe('Manual Stack Deployment', () => {
       assert.isNull(responses[0], 'serverless stack')
       assert.isOk(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
+      assert.isOk(responses[3], 'tertiary stack')
       assert.equal(responses[1].StackStatus, 'CREATE_COMPLETE', 'primary stack')
       assert.equal(responses[2].StackStatus, 'CREATE_COMPLETE', 'secondary stack')
+      assert.equal(responses[3].StackStatus, 'CREATE_COMPLETE', 'tertiary stack')
     })
   })
 
@@ -253,8 +279,10 @@ describe('Manual Stack Deployment', () => {
       assert.isNull(responses[0], 'serverless stack')
       assert.isOk(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
+      assert.isOk(responses[3], 'tertiary stack')
       assert.equal(responses[1].StackStatus, 'CREATE_COMPLETE', 'primary stack')
       assert.equal(responses[2].StackStatus, 'UPDATE_COMPLETE', 'secondary stack')
+      assert.equal(responses[3].StackStatus, 'CREATE_COMPLETE', 'tertiary stack')
     })
   })
 
@@ -274,6 +302,7 @@ describe('Manual Stack Deployment', () => {
       assert.isOk(responses[0], 'serverless stack')
       assert.isNull(responses[1], 'primary stack')
       assert.isNull(responses[2], 'secondary stack')
+      assert.isNull(responses[3], 'tertiary stack')
       assert.equal(responses[0].StackStatus, 'UPDATE_COMPLETE', 'serverless stack')
     })
   })
@@ -297,7 +326,8 @@ describe('Individual Stack Deployment', () => {
       assert.isNull(responses[0], 'serverless stack')
       assert.isNull(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
-      assert.equal(responses[2].StackStatus, 'CREATE_COMPLETE', 'primary stack')
+      assert.equal(responses[2].StackStatus, 'CREATE_COMPLETE', 'secondary stack')
+      assert.isNull(responses[3], 'tertiary stack')
     })
   })
 
@@ -314,6 +344,7 @@ describe('Individual Stack Deployment', () => {
       assert.isNull(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
       assert.equal(responses[2].StackStatus, 'CREATE_COMPLETE', 'secondary stack')
+      assert.isNull(responses[3], 'tertiary stack')
     })
   })
 
@@ -330,6 +361,7 @@ describe('Individual Stack Deployment', () => {
       assert.isNull(responses[1], 'primary stack')
       assert.isOk(responses[2], 'secondary stack')
       assert.equal(responses[2].StackStatus, 'UPDATE_COMPLETE', 'secondary stack')
+      assert.isNull(responses[3], 'tertiary stack')
     })
   })
 
@@ -345,6 +377,7 @@ describe('Individual Stack Deployment', () => {
       assert.isNull(responses[0], 'serverless stack')
       assert.isNull(responses[1], 'primary stack')
       assert.isNull(responses[2], 'secondary stack')
+      assert.isNull(responses[3], 'tertiary stack')
     })
   })
 })


### PR DESCRIPTION
This pull request adds the functionality which checks if each additional stack is defined as an array rather than an object. If it is an array, it will be flattened, with the keys of each array object being combined into a final object.

The result is that complex stacks can be split into multiple files, like so:

```
custom:
  additionalStacks:
    permanent: 
        -${file(resources/s3.yml)}
        -${file(resources/meta.yml)}
```

Here is an example for the individual files:

`s3.yml`

```
Resources:
  S3LambdaInstance:
    Type: AWS::S3::Bucket
```

`meta.yml`

```
Deploy: After
StackName: persistent-data
Tags:
  Owner: yetanother@example.org
```

The above example would thus render like so. Note the dashes, indicating that `permanent` is an array of objects, rather than an object containing keys:

```
custom:
  additionalStacks:
    permanent: 
        - Resources:
            S3LambdaInstance:
                Type: AWS::S3::Bucket
        - Deploy: After
          StackName: persistent-data
          Tags:
              Owner: yetanother@example.org
```

With this pull request, using code adapted from [Serverless Core](https://github.com/serverless/serverless/blob/73107822945a878abbdebe2309e8e9d87cc2858a/lib/classes/Service.js#L157)'s implementation of resource handling, any elements of `additionalStacks` which contain an array rather than an object will be flattened into an object, like so:

```
custom:
  additionalStacks:
    permanent: 
        Resources:
            S3LambdaInstance:
                Type: AWS::S3::Bucket
        Deploy: After
        StackName: persistent-data
        Tags:
            Owner: yetanother@example.org
```

This pull request resolves issue #13, and adds a tertiary to the test suite to ensure the correct functionality.