### PR TITLE
Add additional Capability when Transform is detected

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,6 +333,10 @@ class AdditionalStacksPlugin {
       TemplateBody: JSON.stringify(compiledCloudFormationTemplate),
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     }
+    // If the CloudFormation Template has the Transform tag, an additional capability is needed.
+    if (compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push("CAPABILITY_AUTO_EXPAND")
+    }
 
     this.serverless.cli.log('Creating additional stack ' + stackName + '...')
     return this.provider.request(
@@ -369,6 +373,10 @@ class AdditionalStacksPlugin {
       Parameters: deployParameters || [],
       TemplateBody: JSON.stringify(compiledCloudFormationTemplate),
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
+    }
+    // If the CloudFormation Template has the Transform tag, an additional capability is needed.
+    if (compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push("CAPABILITY_AUTO_EXPAND")
     }
 
     return this.provider.request(


### PR DESCRIPTION
Resolves issue #27 

When the additional stacks include a Transform section (which is used to apply a macro, to allow for additional functionality), an additional capability must be added to the provided parameters when creating or updating the stack.